### PR TITLE
Fix the mod crashing on dedicated servers

### DIFF
--- a/src/main/java/com/antoninvf/placeablemaxwell/PlaceableMaxwell.java
+++ b/src/main/java/com/antoninvf/placeablemaxwell/PlaceableMaxwell.java
@@ -8,6 +8,7 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.slf4j.Logger;
@@ -23,6 +24,7 @@ public class PlaceableMaxwell
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
 
         modEventBus.addListener(this::commonSetup);
+        modEventBus.addListener(this::clientSetup);
 
         BlockInit.BLOCKS.register(modEventBus);
         ItemInit.ITEMS.register(modEventBus);
@@ -33,11 +35,14 @@ public class PlaceableMaxwell
 
     private void commonSetup(final FMLCommonSetupEvent event)
     {
+        LOGGER.info("Maxwell says meow!");
+    }
+
+    private void clientSetup(final FMLClientSetupEvent event)
+    {
         ItemBlockRenderTypes.setRenderLayer(BlockInit.MAXWELL_BLOCK.get(), RenderType.cutout());
         ItemBlockRenderTypes.setRenderLayer(BlockInit.MARS_BLOCK.get(), RenderType.cutout());
         ItemBlockRenderTypes.setRenderLayer(BlockInit.VALENOK_BLOCK.get(), RenderType.cutout());
         ItemBlockRenderTypes.setRenderLayer(BlockInit.VASILISA_BLOCK.get(), RenderType.cutout());
-
-        LOGGER.info("Maxwell says meow!");
     }
 }

--- a/src/main/java/com/antoninvf/placeablemaxwell/init/BlockInit.java
+++ b/src/main/java/com/antoninvf/placeablemaxwell/init/BlockInit.java
@@ -16,8 +16,6 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.registries.RegistryObject;
 
-import java.util.function.Supplier;
-
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
 public class BlockInit {
     public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, PlaceableMaxwell.MOD_ID);

--- a/src/main/java/com/antoninvf/placeablemaxwell/init/ItemInit.java
+++ b/src/main/java/com/antoninvf/placeablemaxwell/init/ItemInit.java
@@ -4,7 +4,6 @@ import com.antoninvf.placeablemaxwell.PlaceableMaxwell;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 


### PR DESCRIPTION
This PR moves ItemBlockRenderTypes registration to the *client* setup event, which fixes a crash when the mod is installed on a dedicated server (which is missing the relevant classes, since it has no rendering system).